### PR TITLE
Content for About pages in Analyze tab 

### DIFF
--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -7,6 +7,6 @@ title: "About Methods"
 ## About Methods
 Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, and multi-modal approaches.  This registry lists packages for such computational biology methods.
 
-You can use methods packages by following the installation and usage instructions in the method's detail page.  
+You can use methods packages by following the installation and usage instructions in the method's detail page.  Portal developers can also find instructions for integrating these methods into an app on each method's detail page.
 
 If you are a methodologist and want to add your software to this list, [submit your package](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-methods-package-submission-issue-template)!

--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -5,7 +5,7 @@ title: "About Methods"
 ---
 
 ## About Methods
-Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, multi-modal and other computational biology approaches.  This registry lists packages for such methods.
+Methods for Human Cell Atlas are tools for [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) involving scRNA-seq, scDNA-seq, in situ transcriptomics, multi-modal and other computational biology approaches.  This registry lists packages for such methods.
 
 You can use methods packages by following the installation and usage instructions in the method's detail page.  Portal developers can also find instructions for integrating these methods into an app on each method's detail page.
 

--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -5,7 +5,7 @@ title: "About Methods"
 ---
 
 ## About Methods
-Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, and multi-modal and other computational biology approaches.  This registry lists packages for such methods.
+Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, multi-modal and other computational biology approaches.  This registry lists packages for such methods.
 
 You can use methods packages by following the installation and usage instructions in the method's detail page.  Portal developers can also find instructions for integrating these methods into an app on each method's detail page.
 

--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -5,7 +5,7 @@ title: "About Methods"
 ---
 
 ## About Methods
-Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, and multi-modal approaches.  This registry lists packages for such computational biology methods.
+Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, and multi-modal and other computational biology approaches.  This registry lists packages for such methods.
 
 You can use methods packages by following the installation and usage instructions in the method's detail page.  Portal developers can also find instructions for integrating these methods into an app on each method's detail page.
 

--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -5,3 +5,8 @@ title: "About Methods"
 ---
 
 ## About Methods
+Methods for Human Cell Atlas are tools for tertiary analysis involving scRNA-seq, scDNA-seq, in situ transcriptomics, and multi-modal approaches.  This registry lists packages for such computational biology methods.
+
+You can use methods packages by following the installation and usage instructions in the method's detail page.  
+
+If you are a methodologist and want to add your software to this list, [submit your package](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-methods-package-submission-issue-template)!

--- a/content/analyze/portals/portals-landing.md
+++ b/content/analyze/portals/portals-landing.md
@@ -8,3 +8,5 @@ title: "About Portals"
 Portals for Human Cell Atlas are applications that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) in a graphical user interface.  They provide a human-friendly UI in a web or native app to search, explore and analyze biological data.  
 
 [Start analyzing Human Cell Atlas](/analyze/portals) today!  Simply click the "View" button beside a portal summary to navigate.  You can also seamlessly load your dataset of interest by clicking the "Use with HCA Data" link for enabled portals.
+
+If you are a portal developer and want to add your software to this list, [submit your app](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-portals-app-submission-issue-template)!

--- a/content/analyze/portals/portals-landing.md
+++ b/content/analyze/portals/portals-landing.md
@@ -5,3 +5,6 @@ title: "About Portals"
 ---
 
 ## About Portals
+Portals for Human Cell Atlas are applications that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) in a graphical user interface.  They provide a human-friendly UI in a web or native app to search, explore and analyze biological data.  
+
+[Start analyzing Human Cell Atlas](/analyze/portals) today!  Simply click the "View" button beside a portal summary to navigate.  You can also seamlessly load your dataset of interest by clicking the "Use with HCA Data" link for enabled portals.

--- a/content/analyze/visualization-components/visualization-components-landing.md
+++ b/content/analyze/visualization-components/visualization-components-landing.md
@@ -5,3 +5,8 @@ title: "About Visualization Components"
 ---
 
 ## About Visualization Components
+Visualization components for Human Cell Atlas are JavaScript modules that enable tertiary analysis through interactive data exploration on the web.  This registry lists packages for such components.
+
+You can use these visualization components in portals for HCA data, or you can try out interactive demos in the component's detail page.  Portal developers can also find instructions for integrating these visualizations into a web app on each component's detail page.
+
+If you are a visualization engineer and want to add your software to this list, [submit your package](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-visualization-component-package-submission-issue-template)!

--- a/content/analyze/visualization-components/visualization-components-landing.md
+++ b/content/analyze/visualization-components/visualization-components-landing.md
@@ -5,7 +5,7 @@ title: "About Visualization Components"
 ---
 
 ## About Visualization Components
-Visualization components for Human Cell Atlas are JavaScript modules that enable tertiary analysis through interactive data exploration on the web.  This registry lists packages for such components.
+Visualization components for Human Cell Atlas are JavaScript modules that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) through interactive data exploration on the web.  This registry lists packages for such components.
 
 You can use these visualization components in portals for HCA data, or you can try out interactive demos in the component's detail page.  Portal developers can also find instructions for integrating these visualizations into a web app on each component's detail page.
 


### PR DESCRIPTION
This is an initial draft of content for the About pages in the Analyze tab of the HCA Data Portal.  Feedback welcome!

For each of the three registry areas -- portals, methods, and visualization components -- an About page explains:
* What is listed here?
* How can I use the things that are listed?
* If I build such things, how can I add them to the list?

We'll presumably also need a way to add prototype content for the list view and detail view for each app or package in its respective registry area.  But perhaps that's best for a subsequent PR.