### PR TITLE
Move About pages for Analyze tab

### DIFF
--- a/content/analyze/methods/methods-landing.md
+++ b/content/analyze/methods/methods-landing.md
@@ -1,0 +1,12 @@
+---
+path: "/analyze/methods/methods-landing"	
+date: "2018-05-03"	
+title: "About Methods"
+---
+
+## About Methods
+Methods for Human Cell Atlas are tools for [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) involving scRNA-seq, scDNA-seq, in situ transcriptomics, multi-modal and other computational biology approaches.  This registry lists packages for such methods.
+
+You can use methods packages by following the installation and usage instructions in the method's detail page.  Portal developers can also find instructions for integrating these methods into an app on each method's detail page.
+
+If you are a methodologist and want to add your software to this list, [submit your package](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-methods-package-submission-issue-template)!

--- a/content/analyze/portals/visualization-portals.md
+++ b/content/analyze/portals/visualization-portals.md
@@ -4,4 +4,9 @@ date: "2018-05-03"
 title: "Visualization Portals"
 ---
 
-## Visualization Portals
+## About Portals
+Portals for Human Cell Atlas are applications that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) in a graphical user interface.  They provide a human-friendly UI in a web or native app to search, explore and analyze biological data.  
+
+[Start analyzing Human Cell Atlas](/analyze/portals) today!  Simply click the "View" button beside a portal summary to navigate.  You can also seamlessly load your dataset of interest by clicking the "Use with HCA Data" link for enabled portals.
+
+If you are a portal developer and want to add your software to this list, [submit your app](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?with-portals-app-submission-issue-template)!

--- a/content/analyze/portals/visualization-portals.md
+++ b/content/analyze/portals/visualization-portals.md
@@ -1,7 +1,7 @@
 ---
 path: "/analyze/portals/visualization-portals"
 date: "2018-05-03"
-title: "Visualization Portals"
+title: "About Portals"
 ---
 
 ## About Portals


### PR DESCRIPTION
This moves About content in Analyze tab from its original location in PR #4.