### PR TITLE
Add lists for Methods and Visualization Components tabs

### DIFF
--- a/content/analyze/methods/methods.md
+++ b/content/analyze/methods/methods.md
@@ -4,7 +4,5 @@ date: "2018-05-03"
 title: "Methods"
 componentName: "analyze"
 linked:
-    - ./scfind.md
+    - ./scmap.md
 ---
-
-## Visualization Portals

--- a/content/analyze/methods/methods.md
+++ b/content/analyze/methods/methods.md
@@ -1,0 +1,10 @@
+---
+path: "/analyze/methods"
+date: "2018-05-03"
+title: "Methods"
+componentName: "analyze"
+linked:
+    - ./scfind.md
+---
+
+## Visualization Portals

--- a/content/analyze/portals/asap.md
+++ b/content/analyze/portals/asap.md
@@ -4,6 +4,6 @@ date: "2018-05-03"
 title: "Automated Single cell Analysis Platform (ASAP) | Vincent Gardeux, Fabrice David, Bart Deplancke"
 subTitle: "SAP allows the user to perform custom analyses and compare algorithms for each step of the single cell or bulk RNA-seq analysis pipeline post genome alignment via an intuitive web interface (Gardeux et al., Bioinformatics, 2017). These steps include parsing, filtering, and normalization of the input gene expression matrix, visual (2D and 3D) representation, differential expression, clustering, heatmaps, trajectory inference and functional enrichment analyses to characterize novel cell clusters, specific cell types, or differentiation processes. Thus, ASAP has been developed to lower the bioinformatic entry level to single cell experiments and to catalyze collaborations between computational biologists and experimentalists via an easy-to-use data interaction portal."
 appUrl: "https://asap.epfl.ch/"
-githubUrl:: "https://asap.epfl.ch/"
+githubUrl: "https://asap.epfl.ch/"
 ---
 

--- a/content/analyze/portals/portals-overview.md
+++ b/content/analyze/portals/portals-overview.md
@@ -5,7 +5,7 @@ title: "About Portals"
 ---
 
 ## About Portals
-Portals for Human Cell Atlas are applications that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) in a graphical user interface.  They provide a human-friendly UI in a web or native app to search, explore and analyze biological data.  
+Portals for Human Cell Atlas are applications that enable tertiary analysis in a graphical user interface.  They provide a human-friendly UI in a web or native app to search, explore and analyze biological data.  
 
 [Start analyzing Human Cell Atlas](/analyze/portals) today!  Simply click the "View" button beside a portal summary to navigate.  You can also seamlessly load your dataset of interest by clicking the "Use with HCA Data" link for enabled portals.
 

--- a/content/analyze/portals/ucsc-cell-browser.md
+++ b/content/analyze/portals/ucsc-cell-browser.md
@@ -4,5 +4,5 @@ date: "2018-05-03"
 title: "UCSC Cell Browser | Max Haeussler"
 subTitle: "UCSC Cell Browser is a software tool for single cell RNA expression, a 2D viewer that shows cells as a dimensionality reduction plot with the expression data overlaid. The viewer allows a visual comparison of large single-cell datasets in 2D, overlaying metadata, marker gene levels and cell clustering information. This is be useful when comparing single cell layout (dimensionality reduction) methods and batch correction methods."
 appUrl: "http://cells.ucsc.edu/"
-githuvUrl: "http://cells.ucsc.edu/"
+githubUrl: "http://cells.ucsc.edu/"
 ---

--- a/content/analyze/portals/ucsc-cell-browser.md
+++ b/content/analyze/portals/ucsc-cell-browser.md
@@ -2,7 +2,7 @@
 path: "/analyze/portals/ucsc-cell-browser"
 date: "2018-05-03"
 title: "UCSC Cell Browser | Max Haeussler"
-subTitle: "Pellentesque ornare sem lacinia quam venenatis vestibulum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Nullam quis risus eget urna mollis ornare vel eu leo."
+subTitle: "UCSC Cell Browser is a software tool for single cell RNA expression, a 2D viewer that shows cells as a dimensionality reduction plot with the expression data overlaid. The viewer allows a visual comparison of large single-cell datasets in 2D, overlaying metadata, marker gene levels and cell clustering information. This is be useful when comparing single cell layout (dimensionality reduction) methods and batch correction methods."
 appUrl: "http://cells.ucsc.edu/"
 githuvUrl: "http://cells.ucsc.edu/"
 ---

--- a/content/analyze/portals/visualization-portals.md
+++ b/content/analyze/portals/visualization-portals.md
@@ -1,7 +1,7 @@
 ---
-path: "/analyze/portals/visualization-portals"
+path: "/analyze/portals"
 date: "2018-05-03"
-title: "Visualization Portals"
+title: "Portals"
 componentName: "analyze"
 linked:
     - ./ucsc-cell-browser.md

--- a/content/analyze/portals/visualization-portals.md
+++ b/content/analyze/portals/visualization-portals.md
@@ -5,7 +5,6 @@ title: "Portals"
 componentName: "analyze"
 linked:
     - ./ucsc-cell-browser.md
-    - ./cell-by-gene.md
     - ./ucsc-xena.md
     - ./single-cell-portal.md
     - ./genepattern-notebook.md   

--- a/content/analyze/visualization-components/visualization-components-overview.md
+++ b/content/analyze/visualization-components/visualization-components-overview.md
@@ -5,7 +5,7 @@ title: "About Visualization Components"
 ---
 
 ## About Visualization Components
-Visualization components for Human Cell Atlas are JavaScript modules that enable [tertiary analysis](https://putalinkhere.com/what-is-tertiary-analysis) through interactive data exploration on the web.  This registry lists packages for such components.
+Visualization components for Human Cell Atlas are JavaScript modules that enable tertiary analysis through interactive data exploration on the web.  This registry lists packages for such components.
 
 You can use these visualization components in portals for HCA data, or you can try out interactive demos in the component's detail page.  Portal developers can also find instructions for integrating these visualizations into a web app on each component's detail page.
 

--- a/content/analyze/visualization-components/visualization-components.md
+++ b/content/analyze/visualization-components/visualization-components.md
@@ -8,4 +8,3 @@ linked:
     - ./ideogram.md
 ---
 
-## Visualization Portals

--- a/content/analyze/visualization-components/visualization-components.md
+++ b/content/analyze/visualization-components/visualization-components.md
@@ -1,0 +1,11 @@
+---
+path: "/analyze/visualization-components"
+date: "2018-05-03"
+title: "Visualization components"
+componentName: "analyze"
+linked:
+    - ./anatomogram.md
+    - ./ideogram.md
+---
+
+## Visualization Portals


### PR DESCRIPTION
This add lists for Methods and Visualization Components tabs, like the Portals tab.

It also refines the Portals tab to use the title "Portals" instead of "Visualization Portals", and likewise refines the path.