### PR TITLE
Add basic links to API developer docs

### DIFF
--- a/content/build/api-documentation/data-store-consumer-api.md
+++ b/content/build/api-documentation/data-store-consumer-api.md
@@ -5,5 +5,5 @@ title: "Data store consumer API"
 ---
 
 ## Overview API Documentation
-
+The Data Store has an application programmer interface available for developers. Python programmers can use our HCA Python library. We also provide a REST interface library. The Python library is documented [here](https://hca.readthedocs.io/en/latest/) and the REST interface is documented in Swagger and can be viewed [here](https://dss.integration.data.humancellatlas.org/).
 


### PR DESCRIPTION
For now, I have added links to the documentation we have