### PR TITLE
Frontmatter for no navigation added to privacy

### DIFF
--- a/content/privacy/privacy/privacy.md
+++ b/content/privacy/privacy/privacy.md
@@ -2,6 +2,7 @@
 path: "/privacy/privacy/privacy"
 date: "2018-05-03"
 title: "Privacy"
+noNav: true
 ---
 
 ## Privacy Notice for Human Cell Atlas Data Portal Public Website


### PR DESCRIPTION
- Privacy page has no navigation and so frontmatter added to prevent select box from showing on mobile view