### PR TITLE
added link to portal submission request

### DIFF
--- a/content/contribute/data/analysis-tools-registry.md
+++ b/content/contribute/data/analysis-tools-registry.md
@@ -7,17 +7,19 @@ title: "Contributing to the Analysis Tools Registry"
 ## Contributing to the Analysis Tools Registry
 The [Analysis Tools Registry](/analyze) lists portals, methods packages, and visualization packages.  Computational biologists submit packages for use by software engineers in portal development. [Analysis Tools Registry standards](/contribute/analysis-tools-registry/registry-standards) promote software best practices and help facilitate ease of package deployment by non-biologists (e.g. software engineers) and non-computational biologists.
 
-The package details pages provide software engineers with information (basic command line usage, code repository location, etc.) and resources (Docker image URL, contact name and email etc.) to support rapid incorporation of these packages into web portals.
-
 ### Submission Forms
-Methods and visualizations are submitted using GitHub. Use these links to access the submission forms.
+Submissions are contributed via GitHub - use these links to access the submission forms:
 
+[Portal submission](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?template=submit-portal.md)\
 [Methods package submission](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?template=submit-method-package.md)\
 [Visualization package submission](https://github.com/HumanCellAtlas/data-portal-content/issues/new/?template=submit-visualization-component-package.md)
 
-Below, we provide details about the information requested in the forms.
+Below, we provide details about the information requested in the methods and visualizations submission forms.
 
 ### Package Submission Field Details
+
+The package details pages provide software engineers with information (basic command line usage, code repository location, etc.) and resources (Docker image URL, contact name and email etc.) to support rapid incorporation of these packages into web portals.
+
 #### Required Submission Fields for Methods and Visualizations
 - Package title
     - Name of method or visualization


### PR DESCRIPTION
The "submit here" link at https://prod.data.humancellatlas.org/analyze no longer points to the submission template and instead points to https://prod.data.humancellatlas.org/contribute/analysis-tools-registry. This change provides consistency because the methods and visualization tabs also point to the analysis-tools-registry page. For the linkage to be meaningful, however, the analysis-tools-registry needs to have a link to the submission template. This pull request adds the submission link and makes minor changes to fit the link into a page which is largely focused on methods and visualization packages.