### PR TITLE
Check for any hard links to prod.data.humancellatlas.org in content. Resolves db- 471.

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-method-package.md
+++ b/.github/ISSUE_TEMPLATE/submit-method-package.md
@@ -6,10 +6,10 @@ about: Create or update a computational methodology package
 
 Thank you for submitting a method package to the HCA DCP Analysis Tools Registry!
 
-To expedite your package's addition to https://prod.data.humancellatlas.org/analyze/methods,
-please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your package's detail page ([example](https://prod.data.humancellatlas.org/analyze/methods/stream)).
+To expedite your package's addition to https://data.humancellatlas.org/analyze/methods,
+please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your package's detail page ([example](https://data.humancellatlas.org/analyze/methods/stream)).
 
-[Required](https://prod.data.humancellatlas.org/contribute/analysis-tools-registry#package-submission-field-details):
+[Required](https://data.humancellatlas.org/contribute/analysis-tools-registry#package-submission-field-details):
 - Tool title: 
 - Contact name: 
 - Contact email: 
@@ -24,7 +24,7 @@ please provide the following package metadata.  You can easily edit this informa
 - Command to validate installation:
 - Short description: (<= 200 characters, will appear on list page)
 
-[Optional](https://prod.data.humancellatlas.org/contribute/analysis-tools-registry#optional-fields-for-methods-and-visualizations):
+[Optional](https://data.humancellatlas.org/contribute/analysis-tools-registry#optional-fields-for-methods-and-visualizations):
 - Long description: (will appear on detail page)
 - Build badge URL: (e.g. https://travis-ci.org/kstreet13/slingshot.svg?branch=master)
 - Coverage badge URL: (e.g. https://img.shields.io/codecov/c/github/kstreet13/slingshot/master.svg)

--- a/.github/ISSUE_TEMPLATE/submit-portal.md
+++ b/.github/ISSUE_TEMPLATE/submit-portal.md
@@ -1,13 +1,12 @@
 ---
 name: Submit portal
 about: Create or update a portal listing
-
 ---
 
 Thank you for submitting a portal to the HCA DCP Methods Registry!
 
-To expedite your portal's addition to https://prod.data.humancellatlas.org/analyze/portals,
-please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your portal's detail page ([example](https://prod.data.humancellatlas.org/analyze/portals/asap)).
+To expedite your portal's addition to https://data.humancellatlas.org/analyze,
+please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your portal's detail page ([example](https://data.humancellatlas.org/analyze/portals/asap)).
 
 Required:
 - Tool title: 

--- a/.github/ISSUE_TEMPLATE/submit-visualization-component-package.md
+++ b/.github/ISSUE_TEMPLATE/submit-visualization-component-package.md
@@ -6,10 +6,10 @@ about: Create or update a visualization component package
 
 Thank you for submitting a visualization component package to the HCA DCP Methods Registry!
 
-To expedite your package's addition to https://prod.data.humancellatlas.org/analyze/visualization,
-please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your package's detail page ([example](https://prod.data.humancellatlas.org/analyze/visualization/anatomogram)).
+To expedite your package's addition to https://data.humancellatlas.org/analyze/visualization,
+please provide the following package metadata.  You can easily edit this information later by clicking "Improve this page" at the bottom of your package's detail page ([example](https://data.humancellatlas.org/analyze/visualization/anatomogram)).
 
-[Required](https://prod.data.humancellatlas.org/contribute/analysis-tools-registry#package-submission-field-details):
+[Required](https://data.humancellatlas.org/contribute/analysis-tools-registry#package-submission-field-details):
 - Tool title: 
 - Contact name: 
 - Contact email: 
@@ -20,7 +20,7 @@ please provide the following package metadata.  You can easily edit this informa
 - NPM package provides ES6 export?: [ ] (fill in as [x] to indicate your package provides an ES6 export)
 - Short description: (<= 200 characters, will appear on list page)
 
-[Optional](https://prod.data.humancellatlas.org/contribute/analysis-tools-registry#optional-fields-for-methods-and-visualizations):
+[Optional](https://data.humancellatlas.org/contribute/analysis-tools-registry#optional-fields-for-methods-and-visualizations):
 - Long description: (will appear on detail page)
 - Build badge URL: (e.g. https://travis-ci.org/eweitz/ideogram.svg?branch=master)
 - Coverage badge URL: (e.g. https://coveralls.io/repos/github/eweitz/ideogram/badge.svg)


### PR DESCRIPTION
- Prod links removed from submit-method-package.md, submit-portal.md, submit-visualization-component-package.md.
- Hard links remain for these three *.md files as they are used externally by github (example https://github.com/HumanCellAtlas/data-portal-content/issues/new/?template=submit-method-package.md).
- No hard links in `data-portal`.